### PR TITLE
List Renders From DB & Other Fixes

### DIFF
--- a/src/actions/elementsActions.js
+++ b/src/actions/elementsActions.js
@@ -9,7 +9,7 @@ export function selectElement (elementId) {
   return {
     type: 'SELECT_ELEMENT',
     data: {
-      elementId: elementId,
+      elementId: elementId
     }
   }
 }

--- a/src/components/ImgComp.js
+++ b/src/components/ImgComp.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 
 class ImgComp extends Component {
   render () {
-    console.log('img', this.props);
     return (
       <div
         style={

--- a/src/components/ListComp.js
+++ b/src/components/ListComp.js
@@ -2,16 +2,13 @@ import React, { Component } from 'react';
 
 class ListComp extends Component {
   render() {
-    const listArray = ['yellow', 'green', 'orange', 'pink'].map((color, index) => {
+    const listArray = this.props.list.map((listItem, index) => {
       return (
         <li
-          key={index}
+          key={listItem.elementId}
+          elementId={listItem.elementId}
           className="listItem"
-          style={
-            {
-              backgroundColor: color
-            }
-          }
+          style={listItem.style}
         >
           I'm a list item!
         </li>

--- a/src/components/ListComp.js
+++ b/src/components/ListComp.js
@@ -3,10 +3,10 @@ import React, { Component } from 'react';
 class ListComp extends Component {
   render() {
     const listArray = this.props.list.map((listItem, index) => {
+      console.log(listItem);
       return (
         <li
           key={listItem.elementId}
-          elementId={listItem.elementId}
           className="listItem"
           style={listItem.style}
         >

--- a/src/containers/Template.js
+++ b/src/containers/Template.js
@@ -7,7 +7,6 @@ class Template extends Component {
     super(props);
   }
   render() {
-    console.log(this.props);
     const divTags = this.props.divTags.map((div, index) => {
       return (
         <DivComp
@@ -15,17 +14,20 @@ class Template extends Component {
           elementId={div.elementId}
           style={div.style}
           selectElement={this.props.selectElement}
+          pTags={this.props.pTags}
         />
       )
     })
     const pTags = this.props.pTags.map((p, index) => {
       return (
-        <PComp
-          key={p.elementId}
-          elementId={p.elementId}
-          style={p.style}
-          selectElement={this.props.selectElement}
-        />
+        <div>
+          <PComp
+            key={p.elementId}
+            elementId={p.elementId}
+            style={p.style}
+            selectElement={this.props.selectElement}
+          />
+        </div>
       )
     })
     const imgTags = this.props.imgTags.map((img, index) => {

--- a/src/containers/Template.js
+++ b/src/containers/Template.js
@@ -39,6 +39,16 @@ class Template extends Component {
         />
       )
     })
+    const ulTags = this.props.ulTags.map((ul, index) => {
+      return (
+        <ListComp
+          key={ul.elementId}
+          style={ul.style}
+          list={ul.subType}
+          selectElement={this.props.selectElement}
+        />
+      )
+    })
     return (
       <div
         className="template-one"
@@ -47,7 +57,7 @@ class Template extends Component {
         {imgTags}
         {divTags}
         {pTags}
-        <ListComp />
+        {ulTags}
         <Footer />
       </div>
     )

--- a/src/containers/TemplateEdit.js
+++ b/src/containers/TemplateEdit.js
@@ -31,7 +31,6 @@ class TemplateEdit extends Component {
           return elem.type === 'img';
         });
         let ulTags = elementArray.filter((elem, index) => {
-          console.log(elem.type);
           return elem.type === 'ul';
         });
         return {

--- a/src/containers/TemplateEdit.js
+++ b/src/containers/TemplateEdit.js
@@ -30,10 +30,15 @@ class TemplateEdit extends Component {
         let imgTags = elementArray.filter((elem, index) => {
           return elem.type === 'img';
         });
+        let ulTags = elementArray.filter((elem, index) => {
+          console.log(elem.type);
+          return elem.type === 'ul';
+        });
         return {
           divTags: divTags,
           pTags: pTags,
-          imgTags: imgTags
+          imgTags: imgTags,
+          ulTags: ulTags
         };
       })
       .then((elementObj) => {
@@ -41,7 +46,6 @@ class TemplateEdit extends Component {
       })
   }
   render() {
-    console.log(this.props.elementsReducer.elements.imgTags);
     return(
       <div
         className="template-edit-container"
@@ -50,6 +54,7 @@ class TemplateEdit extends Component {
           divTags={this.props.elementsReducer.elements.divTags}
           pTags={this.props.elementsReducer.elements.pTags}
           imgTags={this.props.elementsReducer.elements.imgTags}
+          ulTags={this.props.elementsReducer.elements.ulTags}
           selectElement={this.props.selectElement}
         />
         <Edit

--- a/src/containers/TemplateEdit.js
+++ b/src/containers/TemplateEdit.js
@@ -49,12 +49,13 @@ class TemplateEdit extends Component {
   showElementStyles(styles){
     let stylesArray = [];
     for (let style in styles) {
-      stylesArray.push(`${style}: ${styles[style]}`);
+      stylesArray.push(`${style}: ${styles[style]},  `);
     }
     return stylesArray;
   }
 
   render() {
+    console.log(this.props.elementsReducer);
     return(
       <div
         className="template-edit-container"
@@ -72,7 +73,7 @@ class TemplateEdit extends Component {
           colorPalette={this.props.colors.colorPalette}
           changeColor={this.props.changeColor}
           changeFont={this.props.changeFont}
-          selectedElement={this.props.elementsReducer.selectedElementId}
+          selectedElement={this.props.elementsReducer.selectedElement.selectedElementId}
         />
       </div>
     )

--- a/src/reducers/elementsReducer.js
+++ b/src/reducers/elementsReducer.js
@@ -2,7 +2,8 @@ const initialState = {
   elements: {
     divTags: [],
     pTags: [],
-    imgTags: []
+    imgTags: [],
+    ulTags: []
   },
   selectedElementId: 0
 };

--- a/src/reducers/elementsReducer.js
+++ b/src/reducers/elementsReducer.js
@@ -26,7 +26,6 @@ const reducer = (state = initialState, action) => {
         })
       }
       return { ...state, selectedElement: selectedElement};
-
     case "CHANGE_COLOR":
       for (let element in newElems) {
         newElems[element] = newElems[element].map((elem, index) => {

--- a/src/reducers/elementsReducer.js
+++ b/src/reducers/elementsReducer.js
@@ -14,6 +14,7 @@ const reducer = (state = initialState, action) => {
     case "SET_ELEMENTS":
       return { ...state, elements: action.data};
     case "SELECT_ELEMENT":
+      console.log(action.data.elementId);
       return { ...state, selectedElementId: action.data.elementId};
     case "CHANGE_COLOR":
       for (let element in newElems) {

--- a/test.js
+++ b/test.js
@@ -41,14 +41,14 @@ db.styles.insert([
         elementId: 6,
         type: 'li',
         style: {
-          backgroundColor: 'blue'
+          backgroundColor: 'pink'
         }
       },
       {
         elementId: 7,
         type: 'li',
         style: {
-          backgroundColor: 'red'
+          backgroundColor: 'orange'
         }
       }
     ],

--- a/test.js
+++ b/test.js
@@ -36,6 +36,22 @@ db.styles.insert([
   {
     elementId: 4,
     type: 'ul',
+    subType: [
+      {
+        elementId: 6,
+        type: 'li',
+        style: {
+          backgroundColor: 'blue'
+        }
+      },
+      {
+        elementId: 7,
+        type: 'li',
+        style: {
+          backgroundColor: 'red'
+        }
+      }
+    ],
     style: {
       color: 'red'
     }


### PR DESCRIPTION
List can now render by finding the <ul> tag. Lists will inherently have an embedded "subType" field so we can map over it and render those as the <li> tags. Basic concept should be the same when we want to wrap things in divs.

Also modified code to pass down a selected style object through the store.