### PR TITLE
Removed brackets from `ListItem` import.

### DIFF
--- a/src/components/Template/ListComp.js
+++ b/src/components/Template/ListComp.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { ListItem } from './ListItem';
+import ListItem from './ListItem';
 
 class ListComp extends Component {
   render() {


### PR DESCRIPTION
- Brackets on `{ ListItem }` was causing errors.