### PR TITLE
Redirect route to template

### DIFF
--- a/scss/styles.scss
+++ b/scss/styles.scss
@@ -558,6 +558,7 @@ a{
 }
 .row-notfound{
   padding: 75px 0;
+  flex:flex-end;
   .flex-nowrap-notfound-container{
     margin: 0 50px;
     display: flex;

--- a/src/containers/TemplateEdit.js
+++ b/src/containers/TemplateEdit.js
@@ -30,10 +30,12 @@ class TemplateEdit extends Component {
         }
       }
     })
-    .then(() => {
-      setTimeout(() => {
-        browserHistory.push('/template');
-      }, 3000)
+    .then((result) => {
+      if(result === null){
+        setTimeout(() => {
+          browserHistory.push('/template');
+        }, 3000)
+      }
     });
   }
   loadTheme () {

--- a/src/containers/TemplateEdit.js
+++ b/src/containers/TemplateEdit.js
@@ -34,7 +34,12 @@ class TemplateEdit extends Component {
       if(result === null){
         setTimeout(() => {
           browserHistory.push('/template');
-        }, 3000)
+        }, 5000)
+      } else {
+        return $.ajax({
+          url: `/api/template/${this.props.params.hash}`,
+          dataType: 'json'
+        })
       }
     });
   }

--- a/src/containers/TemplateEdit.js
+++ b/src/containers/TemplateEdit.js
@@ -3,7 +3,7 @@ import { Template , Edit, CssView, NotFound } from './';
 import { connect } from 'react-redux';
 
 import * as Actions from '../actions';
-import { browserHistory } from 'react-router';
+import { Router, Route, browserHistory } from 'react-router';
 
 function mapStateToProps (state) {
   return { ...state};
@@ -22,11 +22,6 @@ class TemplateEdit extends Component {
       success: function (result) {
         if(result === null)  {
           browserHistory.push('NotFound')
-          .then(() => {
-            setTimeout(() => {
-              this.loadSavedTheme();
-            }, 3000);
-          })
         }
       },
       error: function (result) {

--- a/src/containers/TemplateEdit.js
+++ b/src/containers/TemplateEdit.js
@@ -29,6 +29,11 @@ class TemplateEdit extends Component {
           browserHistory.push('NotFound')
         }
       }
+    })
+    .then(() => {
+      setTimeout(() => {
+        browserHistory.push('/template');
+      }, 3000)
     });
   }
   loadTheme () {

--- a/src/containers/TemplateEdit.js
+++ b/src/containers/TemplateEdit.js
@@ -21,12 +21,17 @@ class TemplateEdit extends Component {
       dataType: 'json',
       success: function (result) {
         if(result === null)  {
-          browserHistory.push('NotFound');
+          browserHistory.push('NotFound')
+          .then(() => {
+            setTimeout(() => {
+              this.loadSavedTheme();
+            }, 3000);
+          })
         }
       },
       error: function (result) {
         if(result === null) {
-          browserHistory.push('NotFound');
+          browserHistory.push('NotFound')
         }
       }
     });


### PR DESCRIPTION
If the user happens to accidentally types the wrong hash for the template, it redirects them to the 404 page, but it will also redirect them to the template page...

- Added in the Save Template $ajax call...
- Checks on the success and error, but will still return to render the Save Template...